### PR TITLE
fix L definition

### DIFF
--- a/15-19-te-de/15-19-te-de.tex
+++ b/15-19-te-de/15-19-te-de.tex
@@ -886,7 +886,7 @@ which can be written as the Helmholtz equation of applied mathematics:
 %
 \begin{align*}
 \nabla^2 \phi(\vec{r}) - \frac{1}{L^2}\phi(\vec{r}) &= \frac{-Q(\vec{r})}{D}\:, \\
-\text{where }\qquad L &\equiv \frac{D}{\Sigma_a}\:.
+\text{where }\qquad L &\equiv \sqrt{\frac{D}{\Sigma_a}}\:.
 \end{align*}
 %
 $L$ is called the neutron diffusion length. This is ``how far a neutron diffuses from a source prior to absorption". 


### PR DESCRIPTION
Fixes the definition of neutron diffusion length to be consistent with notation.
