### PR TITLE
fixed notation so definitions and derivation are consistent

### DIFF
--- a/04-te/04-defs-te.tex
+++ b/04-te/04-defs-te.tex
@@ -151,18 +151,18 @@ $\vec{j}(\vec{r}, E, \vOmega, t) \cdot \hat{e}\: dA\: dE\: d\vOmega$ is the expe
 \subsection*{The transport equation}
 We consider a six-dimensional volume (as a six-dimensional cube)
  fixed in space, of dimensions
-$\triangle x$, $\triangle y$, $\triangle z$, $\triangle E$, $\triangle \mu$, $\triangle \overline\varphi$.
+$\triangle x$, $\triangle y$, $\triangle z$, $\triangle E$, $\triangle \theta$, $\triangle \varphi$.
 Then, the number of particles within this volume at time $t$ is
 \begin{equation*}
-N(\rvec,E,\omvec,t)\triangle x\triangle y\triangle z\triangle E\triangle \mu\triangle \overline\varphi =
-N(\rvec,E,\omvec,t)\triangle \beta,
+n(\rvec,E,\omvec,t)\triangle x\triangle y\triangle z\triangle E\triangle \theta\triangle \varphi =
+n(\rvec,E,\omvec,t)\triangle \beta,
 \end{equation*}
 where all arguments of $N$ are ``average" arguments in the %volume $\triangle V$.
 increment of six-dimensional phase space $\triangle \beta$.
 The number of
 particles in this cube changes with time:
 \begin{equation*}
-\triangle \beta\frac{\partial}{\partial t}N(\rvec,E,\omvec,t) = \begin{array}{l}
+\triangle \beta\frac{\partial}{\partial t}n(\rvec,E,\omvec,t) = \begin{array}{l}
 \text{time rate of change of the number of}\vspace{-0.1cm}\\
 \text{particles in the six-dimensional cube $\triangle \beta$.}
 \end{array}
@@ -177,45 +177,45 @@ as outscattering; the rate of scattering into $E$, $\omvec$ from all other energ
  Now, let us consider the surfaces of the cube perpendicular to the $x$-axis. For the net rate
 of particles leaving the cube through these two surfaces, we have
 \begin{equation*}
-(\textrm{Streaming})_x = \dot x N(\rvec,E,\omvec,t)\mid_x^{x+\triangle x}
-\triangle y\triangle z\triangle E\triangle \mu\triangle \overline\varphi,
+(\textrm{Streaming})_x = \dot x n(\rvec,E,\omvec,t)\mid_x^{x+\triangle x}
+\triangle y\triangle z\triangle E\triangle \theta \triangle\varphi,
 \end{equation*}
  where $\dot x$ is the $x$ component of the particle velocity,
 and 
-$\triangle y\triangle z\triangle E\triangle\mu\triangle \overline\varphi$ is the surface area. Letting $\triangle x$ go to
+$\triangle y\triangle z\triangle E\triangle\theta\triangle \varphi$ is the surface area. Letting $\triangle x$ go to
 the differential $dx$, we rewrite
 \begin{equation*}
 (\textrm{Streaming})_x = \triangle \beta \frac{\partial}{\partial x}\big[
-\dot x N(\rvec,E,\omvec,t)\big].
+\dot x n(\rvec,E,\omvec,t)\big].
 \end{equation*}
  Using the same procedure for the flow from the cube in the other five ``directions", we obtain
 \begin{align*}
 \textrm{Streaming} =
-\bigg[ \frac{\partial}{\partial x}(\dot x N) + &
-\frac{\partial}{\partial y}(\dot y N) +\frac{\partial}{\partial z}(\dot z N) \\
-&\quad\quad + \frac{\partial}{\partial E}(\dot E N) + \frac{\partial}{\partial \mu}(\dot \mu N) +
-\frac{\partial}{\partial \overline{\varphi}}(\dot \varphi N)\bigg] \triangle \beta,
+\bigg[ \frac{\partial}{\partial x}(\dot x n) + &
+\frac{\partial}{\partial y}(\dot y n) +\frac{\partial}{\partial z}(\dot z n) \\
+&\quad\quad + \frac{\partial}{\partial E}(\dot E n) + \frac{\partial}{\partial \theta}(\dot \theta n) +
+\frac{\partial}{\partial \varphi}(\dot \varphi n)\bigg] \triangle \beta,
 \end{align*}
- where $N = N(\rvec,E,\omvec,t)$.
+ where $n = n(\rvec,E,\omvec,t)$.
 
 
  The rate of absorption within the cube is the product of the number of particles in the cube
 and the probability of absorption per particle per unit of time. This probability is given by
 the product of the absorption cross section and the particle speed $v$. That is,
 \begin{equation*}
-\textrm{Absorption} = v\Sigma_a(\rvec,E)N(\rvec ,E,\omvec,t)\triangle \beta.
+\textrm{Absorption} = v\Sigma_a(\rvec,E)n(\rvec ,E,\omvec,t)\triangle \beta.
 \end{equation*}
  Using similar arguments and the fact that we need to sum the scattering from (to) $E$,
 $\omvec$ to (from) all other energies and directions $E'$, $\omvec'$, we find
 \begin{align*}
 \textrm{Outscattering} &= \triangle \beta \int_0^{\infty}\int_{4\pi}
-v\Sigma_s(\rvec,E\rightarrow E', \omvec\rightarrow\omvec')N(\rvec,E,\omvec,t)d\omvec'dE', \\
+v\Sigma_s(\rvec,E\rightarrow E', \omvec\rightarrow\omvec')n(\rvec,E,\omvec,t)d\omvec'dE', \\
 \textrm{Inscattering} &= \triangle \beta \int_0^{\infty}\int_{4\pi}
-v'\Sigma_s(\rvec,E'\rightarrow E, \omvec'\rightarrow\omvec,)N(\rvec,E',\omvec',t)d\omvec'dE',
+v'\Sigma_s(\rvec,E'\rightarrow E, \omvec'\rightarrow\omvec,)n(\rvec,E',\omvec',t)d\omvec'dE',
 \end{align*}
  where $\Sigma_s(\rvec,E'\rightarrow E, \omvec'\rightarrow\omvec)$ is the macroscopic differential scattering cross section. Since the distribution function in the integrand of the outscattering term is independent of
  the integration variables, we can rewrite
-Outscattering as $\triangle \beta v\Sigma_s(\rvec,E)N(\rvec, E, \omvec,t).$
+Outscattering as $\triangle \beta v\Sigma_s(\rvec,E)n(\rvec, E, \omvec,t).$
 Finally, we need to consider the internal source of particles. We
 quantify this source  by introducing the function $S(\rvec, E, \omvec, t)$
 such that the rate of introduction of particles into the cube is given by
@@ -227,31 +227,31 @@ such that the rate of introduction of particles into the cube is given by
 for loss and gain, to the overall rate of change. Letting $\triangle \beta$ approach a differential
 element and canceling it, we obtain
 \begin{align}
-\frac{\partial N}{\partial t} =& -\left[\frac{\partial (\dot x N)}{\partial x} +
-\frac{\partial (\dot y N)}{\partial y}+\frac{\partial (\dot z N)}{\partial z} +
-\frac{\partial (\dot E N)}{\partial E}+\frac{\partial (\dot \mu N)}{\partial \mu}+
-\frac{\partial (\dot \varphi N)}{\partial \overline\varphi}\right] 
-\\ & \quad - v\Sigma_a(\rvec,E)N \nonumber
+\frac{\partial n}{\partial t} =& -\left[\frac{\partial (\dot x n)}{\partial x} +
+\frac{\partial (\dot y n)}{\partial y}+\frac{\partial (\dot z n)}{\partial z} +
+\frac{\partial (\dot E n)}{\partial E}+\frac{\partial (\dot \theta n)}{\partial \theta}+
+\frac{\partial (\dot \varphi n)}{\partial \varphi}\right] 
+\\ & \quad - v\Sigma_a(\rvec,E)n \nonumber
  \\& \quad\quad\quad   + 
-\int_0^{\infty}\int_{4\pi}v'\Sigma_s(\rvec, E'\rightarrow E,\omvec'\rightarrow\omvec)N(\rvec,E',\omvec',t) d\omvec'dE'\nonumber 
-\\& \quad\quad\quad\quad\quad\quad -\int_0^{\infty}\int_{4\pi}v\Sigma_s(\rvec, E\rightarrow E',\omvec\rightarrow\omvec')N(\rvec,E,\omvec,t) d\omvec'dE'\nonumber
+\int_0^{\infty}\int_{4\pi}v'\Sigma_s(\rvec, E'\rightarrow E,\omvec'\rightarrow\omvec)n(\rvec,E',\omvec',t) d\omvec'dE'\nonumber 
+\\& \quad\quad\quad\quad\quad\quad -\int_0^{\infty}\int_{4\pi}v\Sigma_s(\rvec, E\rightarrow E',\omvec\rightarrow\omvec')n(\rvec,E,\omvec,t) d\omvec'dE'\nonumber
 \\& \quad\quad\quad\quad\quad\quad\quad\quad\quad
 +S(\rvec,E,\omvec,t),\nonumber
 \end{align}
- where $N = N(\rvec,E,\omvec,t)$. Since particles travel in a straight line
+ where $n = n(\rvec,E,\omvec,t)$. Since particles travel in a straight line
 between collisions, \linebreak
-$\dot \mu = \dot \varphi = 0$. Furthermore, $\dot E = 0$ because particles stream
+$\dot \theta = \dot \varphi = 0$. Furthermore, $\dot E = 0$ because particles stream
 with no change in energy. Finally, performing the outscattering integral:
 \begin{align}
-&\frac{1}{v}\frac{\partial \varphi}{\partial t}(\rvec,E,\omvec,t) + \omvec\cdot  \nabla \varphi(\rvec,E,\omvec,t) +
- \Sigma_t(\rvec,E)\varphi(\rvec,E,\omvec,t)
+&\frac{1}{v}\frac{\partial \psi}{\partial t}(\rvec,E,\omvec,t) + \omvec\cdot  \nabla \psi(\rvec,E,\omvec,t) +
+ \Sigma_t(\rvec,E)\psi(\rvec,E,\omvec,t)
 \\& \quad =
 \int_0^{\infty}\int_{4\pi}\Sigma_s(\rvec, E'\rightarrow E,\omvec'\rightarrow\omvec)
-\varphi(\rvec,E',\omvec',t)d\omvec'dE'+S(\rvec, E, \omvec,t) \nonumber.
+\psi(\rvec,E',\omvec',t)d\omvec'dE'+S(\rvec, E, \omvec,t) \nonumber.
 \end{align}
 
 We can easily generalize this equation to include nuclear fission.
-To do that, we must revisit our treatment of $\Sigma_a$; as we have mentioned, there are two main processes responsible for the absorption of particles in the system: \textit{radiative capture} and \textit{nuclear fission}. Now, we define
+To do that, we must revisit our treatment of $\Sigma_a$; there are two main processes responsible for the absorption of particles in the system: \textit{radiative capture} and \textit{nuclear fission}. Now, we define
 \begin{align*}
 \Sigma_\gamma(\rvec,E)ds = \textrm{probability of capture}
 \end{align*}
@@ -273,13 +273,13 @@ Of this number, $\nu(E)[1-M(E)]$ are \textit{prompt} fission neutrons (being emi
 Assuming (for simplicity) that the number of delayed neutrons emitted by fission is very small [$M(E)<<1$], we can neglect the delayed neutron terms and rewrite
 the transport equation as
 \begin{align}
-&\frac{1}{v}\frac{\partial \varphi}{\partial t}(\rvec,E,\omvec,t) + \omvec\cdot  \nabla \varphi(\rvec,E,\omvec,t) +
- \Sigma_t(\rvec,E)\varphi(\rvec,E,\omvec,t) 
+&\frac{1}{v}\frac{\partial \psi}{\partial t}(\rvec,E,\omvec,t) + \omvec\cdot  \nabla \psi(\rvec,E,\omvec,t) +
+ \Sigma_t(\rvec,E)\psi(\rvec,E,\omvec,t) 
 \\& \quad\quad\quad\quad =
 \int_0^{\infty}\int_{4\pi}\Sigma_s(\rvec, E'\rightarrow E,\omvec'\rightarrow\omvec)
-\varphi(\rvec,E',\omvec',t)d\omvec'dE'\nonumber
+\psi(\rvec,E',\omvec',t)d\omvec'dE'\nonumber
 \\&\quad\quad\quad\quad\quad\quad +\frac{\chi_p(E)}{4\pi}\int_0^{\infty}\int_{4\pi}\nu(E')\Sigma_f(\rvec,E')
-\varphi(\rvec,E',\omvec',t)d\omvec'dE'\nonumber
+\psi(\rvec,E',\omvec',t)d\omvec'dE'\nonumber
 \\&\quad\quad\quad\quad\quad\quad\quad\quad+S(\rvec, E, \omvec,t) \nonumber.
 \end{align}
    
@@ -291,52 +291,52 @@ volume $V$, it is sufficient to specify the flux of
 particles at all points of the bounding surface of the system in the incoming
 directions. This implies
 \begin{align*}
-\varphi(\rvec_s, E,\omvec,t) &= \varphi_b(\rvec_s,E,\omvec,t)\,, \hspace{0.5 cm} \textbf{n} \cdot \omvec <0,
+\psi(\rvec_s, E,\omvec,t) &= \psi_b(\rvec_s,E,\omvec,t)\,, \hspace{0.5 cm} \textbf{n} \cdot \omvec <0,
 \end{align*}
- where $\varphi_b$ is a specified function at the boundary, $\rvec_s$ is a point on the surface, and $\textbf{n}$ is the unit
+ where $\psi_b$ is a specified function at the boundary, $\rvec_s$ is a point on the surface, and $\textbf{n}$ is the unit
 outward normal vector at this point. In the time variable, we assume the range of
 interest $0\leq t<\infty$ and specify the
 initial condition at $t=0$, such that
 \begin{align*}
-\varphi(\rvec,E,\omvec,0) = \varphi_0(\rvec,E,\omvec),
+\psi(\rvec,E,\omvec,0) = \psi_0(\rvec,E,\omvec),
 \end{align*}
- where $\varphi_0$ is a specified function.
+ where $\psi_0$ is a specified function.
  
 It is common to make extra assumptions in order to obtain a simpler version of these equations. For instance, in the case of time-independent, monoenergetic particle transport in a homogeneous medium with a known interior isotropic source:
 \begin{align*}
-\omvec\cdot  \nabla \varphi(\rvec,\omvec) +
- \Sigma_t\varphi(\rvec,\omvec)
+\omvec\cdot  \nabla \psi(\rvec,\omvec) +
+ \Sigma_t\psi(\rvec,\omvec)
 =
 \int_{4\pi}\Sigma_s(\omvec'\rightarrow\omvec)
-\varphi(\rvec,\omvec')d\omvec'+\frac{S(\rvec)}{4\pi}\,,
+\psi(\rvec,\omvec')d\omvec'+\frac{S(\rvec)}{4\pi}\,,
 \end{align*}
 and 
 \begin{align*}
-\omvec\cdot  \nabla \varphi(\rvec,\omvec) +
- \Sigma_t\varphi(\rvec,\omvec)%\\&
+\omvec\cdot  \nabla \psi(\rvec,\omvec) +
+ \Sigma_t\psi(\rvec,\omvec)%\\&
  &=
 \int_{4\pi}\Sigma_s(\omvec'\rightarrow\omvec)
-\varphi(\rvec,\omvec')d\omvec'\\&\quad\quad\quad\quad\quad\quad
+\psi(\rvec,\omvec')d\omvec'\\&\quad\quad\quad\quad\quad\quad
  +\frac{\nu\Sigma_f}{4\pi}\int_{4\pi}
-\varphi(\rvec,\omvec')d\omvec'+\frac{S(\rvec)}{4\pi}\,.\nonumber
+\psi(\rvec,\omvec')d\omvec'+\frac{S(\rvec)}{4\pi}\,.\nonumber
 \end{align*}
 Both the equations above need a spatial boundary condition, which is given by
 \begin{align*}
-\varphi(\rvec_s,\omvec) = \varphi_b(\rvec_s,\omvec)\,, \hspace{0.5 cm} \textbf{n} \cdot \omvec <0\,.
+\psi(\rvec_s,\omvec) = \psi_b(\rvec_s,\omvec)\,, \hspace{0.5 cm} \textbf{n} \cdot \omvec <0\,.
 \end{align*}
 
-In steady-state reactor calculations, one often sees a version of these equations in which the inhomogeneous source $S(\rvec)$ and the boundary source $\varphi_b(\rvec_s,\omvec)$ are set to zero, and the fission source is modified by a constant factor $1/k$:
+In steady-state reactor calculations, one often sees a version of these equations in which the inhomogeneous source $S(\rvec)$ and the boundary source $\psi_b(\rvec_s,\omvec)$ are set to zero, and the fission source is modified by a constant factor $1/k$:
 \begin{align*}
-&\omvec\cdot  \nabla \varphi(\rvec,\omvec) +
- \Sigma_t\varphi(\rvec,\omvec)%\\&
+&\omvec\cdot  \nabla \psi(\rvec,\omvec) +
+ \Sigma_t\psi(\rvec,\omvec)%\\&
  =
 \int_{4\pi}\Sigma_s(\omvec'\rightarrow\omvec)
-\varphi(\rvec,\omvec')d\omvec'\\&\quad\quad\quad\quad\quad\quad\quad\quad\quad\quad\quad\quad\quad\quad\quad\quad\quad\quad
+\psi(\rvec,\omvec')d\omvec'\\&\quad\quad\quad\quad\quad\quad\quad\quad\quad\quad\quad\quad\quad\quad\quad\quad\quad\quad
  +\frac{\nu\Sigma_f}{4\pi k}\int_{4\pi}
-\varphi(\rvec,\omvec')d\omvec'\,,\nonumber\\
-&\varphi(\rvec_s,\omvec) = 0, \hspace{0.5 cm} \textbf{n} \cdot \omvec <0\,.
+\psi(\rvec,\omvec')d\omvec'\,,\nonumber\\
+&\psi(\rvec_s,\omvec) = 0, \hspace{0.5 cm} \textbf{n} \cdot \omvec <0\,.
 \end{align*}
-These equations always have the zero solution $\varphi = 0$; the goal is to find the largest value of $k$ such that a nonzero solution $\varphi$ exists. The resulting $k$ is called the \textit{criticality} (or \textit{criticality eigenvalue}) of the system. If a system has a fissile region, it can be shown that $k$ always exists, and the corresponding (eigenfunction) $\varphi$ is unique and positive.
+These equations always have the zero solution $\psi = 0$; the goal is to find the largest value of $k$ such that a nonzero solution $\psi$ exists. The resulting $k$ is called the \textit{criticality} (or \textit{criticality eigenvalue}) of the system. If a system has a fissile region, it can be shown that $k$ always exists, and the corresponding (eigenfunction) $\psi$ is unique and positive.
 
 
 \end{document}


### PR DESCRIPTION
Just made notations in the second part consistent with the notations on the definitions.
